### PR TITLE
Add .NET MAUI app with EF Core and MVVM

### DIFF
--- a/CashRegisterMaui/App.xaml
+++ b/CashRegisterMaui/App.xaml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<Application xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="CashRegisterMaui.App">
+    <Application.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="Resources/Styles/Colors.xaml" />
+                <ResourceDictionary Source="Resources/Styles/Styles.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Application.Resources>
+</Application>

--- a/CashRegisterMaui/App.xaml.cs
+++ b/CashRegisterMaui/App.xaml.cs
@@ -1,0 +1,12 @@
+using CashRegisterMaui.Views;
+
+namespace CashRegisterMaui;
+
+public partial class App : Application
+{
+    public App(AppShell shell)
+    {
+        InitializeComponent();
+        MainPage = shell;
+    }
+}

--- a/CashRegisterMaui/AppShell.xaml
+++ b/CashRegisterMaui/AppShell.xaml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<Shell xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+       xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+       xmlns:views="clr-namespace:CashRegisterMaui.Views"
+       x:Class="CashRegisterMaui.Views.AppShell"
+       FlyoutBehavior="Disabled">
+    <ShellContent Route="LoginPage"
+                  ContentTemplate="{DataTemplate views:LoginPage}" />
+    <ShellContent Route="UserDashboardPage"
+                  ContentTemplate="{DataTemplate views:UserDashboardPage}" />
+    <ShellContent Route="AdminDashboardPage"
+                  ContentTemplate="{DataTemplate views:AdminDashboardPage}" />
+</Shell>

--- a/CashRegisterMaui/AppShell.xaml.cs
+++ b/CashRegisterMaui/AppShell.xaml.cs
@@ -1,0 +1,12 @@
+using Microsoft.Maui.Controls;
+
+namespace CashRegisterMaui.Views;
+
+public partial class AppShell : Shell
+{
+    public AppShell()
+    {
+        InitializeComponent();
+        Dispatcher.Dispatch(async () => await GoToAsync("//LoginPage"));
+    }
+}

--- a/CashRegisterMaui/CashRegisterMaui.csproj
+++ b/CashRegisterMaui/CashRegisterMaui.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>CashRegisterMaui</RootNamespace>
+    <UseMaui>true</UseMaui>
+    <SingleProject>true</SingleProject>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="**\*.cs" Exclude="bin\**;obj\**" />
+    <MauiXaml Include="**\*.xaml" Exclude="bin\**;obj\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <MauiIcon Include="Resources\AppIcon\appicon.svg" />
+    <MauiSplashScreen Include="Resources\Splash\splash.svg" Color="#512BD4" />
+    <MauiImage Include="Resources\Images\*" />
+    <MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CommunityToolkit.Maui" Version="8.2.0" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
+    <PackageReference Include="LiveChartsCore.SkiaSharpView.Maui" Version="2.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.4">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.4" />
+    <PackageReference Include="SQLitePCLRaw.bundle_green" Version="2.1.5" />
+  </ItemGroup>
+</Project>

--- a/CashRegisterMaui/CashRegisterMaui.sln
+++ b/CashRegisterMaui/CashRegisterMaui.sln
@@ -1,0 +1,21 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.7.34018.315
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CashRegisterMaui", "CashRegisterMaui.csproj", "{102D82D6-4C0C-4BA1-98E3-86C69353C986}"
+EndProject
+Global
+GlobalSection(SolutionConfigurationPlatforms) = preSolution
+Debug|Any CPU = Debug|Any CPU
+Release|Any CPU = Release|Any CPU
+EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{102D82D6-4C0C-4BA1-98E3-86C69353C986}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{102D82D6-4C0C-4BA1-98E3-86C69353C986}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{102D82D6-4C0C-4BA1-98E3-86C69353C986}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{102D82D6-4C0C-4BA1-98E3-86C69353C986}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
+GlobalSection(SolutionProperties) = preSolution
+HideSolutionNode = FALSE
+EndGlobalSection
+EndGlobal

--- a/CashRegisterMaui/Converters/StringNotEmptyConverter.cs
+++ b/CashRegisterMaui/Converters/StringNotEmptyConverter.cs
@@ -1,0 +1,19 @@
+using System.Globalization;
+using Microsoft.Maui.Controls;
+
+namespace CashRegisterMaui.Converters;
+
+public class StringNotEmptyConverter : IValueConverter
+{
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is string text)
+        {
+            return !string.IsNullOrWhiteSpace(text);
+        }
+
+        return false;
+    }
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => throw new NotSupportedException();
+}

--- a/CashRegisterMaui/Data/AppDbContext.cs
+++ b/CashRegisterMaui/Data/AppDbContext.cs
@@ -1,0 +1,62 @@
+using System.Security.Cryptography;
+using System.Text;
+using CashRegisterMaui.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace CashRegisterMaui.Data;
+
+public class AppDbContext : DbContext
+{
+    public AppDbContext(DbContextOptions<AppDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<User> Users => Set<User>();
+    public DbSet<CashSession> CashSessions => Set<CashSession>();
+    public DbSet<Transaction> Transactions => Set<Transaction>();
+    public DbSet<FlexiTransaction> FlexiTransactions => Set<FlexiTransaction>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        modelBuilder.Entity<User>()
+            .HasIndex(u => u.Username)
+            .IsUnique();
+
+        modelBuilder.Entity<User>().HasData(new User
+        {
+            Id = 1,
+            Username = "admin",
+            PasswordHash = HashPassword("admin"),
+            Role = UserRole.Admin,
+            FullName = "Administrator"
+        });
+
+        modelBuilder.Entity<CashSession>()
+            .HasOne(cs => cs.User)
+            .WithMany(u => u.CashSessions)
+            .HasForeignKey(cs => cs.UserId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        modelBuilder.Entity<Transaction>()
+            .HasOne(t => t.CashSession)
+            .WithMany(cs => cs.Transactions)
+            .HasForeignKey(t => t.CashSessionId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        modelBuilder.Entity<FlexiTransaction>()
+            .HasOne(t => t.CashSession)
+            .WithMany(cs => cs.FlexiTransactions)
+            .HasForeignKey(t => t.CashSessionId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+
+    public static string HashPassword(string password)
+    {
+        using var sha = SHA256.Create();
+        var bytes = Encoding.UTF8.GetBytes(password);
+        var hash = sha.ComputeHash(bytes);
+        return Convert.ToHexString(hash);
+    }
+}

--- a/CashRegisterMaui/Data/DesignTimeDbContextFactory.cs
+++ b/CashRegisterMaui/Data/DesignTimeDbContextFactory.cs
@@ -1,0 +1,17 @@
+using System;
+using System.IO;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+
+namespace CashRegisterMaui.Data;
+
+public class DesignTimeDbContextFactory : IDesignTimeDbContextFactory<AppDbContext>
+{
+    public AppDbContext CreateDbContext(string[] args)
+    {
+        var optionsBuilder = new DbContextOptionsBuilder<AppDbContext>();
+        var dbPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "cashregister.db");
+        optionsBuilder.UseSqlite($"Data Source={dbPath}");
+        return new AppDbContext(optionsBuilder.Options);
+    }
+}

--- a/CashRegisterMaui/Helpers/ServiceHelper.cs
+++ b/CashRegisterMaui/Helpers/ServiceHelper.cs
@@ -1,0 +1,29 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CashRegisterMaui.Helpers;
+
+public static class ServiceHelper
+{
+    private static IServiceProvider? _provider;
+
+    public static void Configure(IServiceProvider provider)
+    {
+        _provider = provider;
+    }
+
+    public static T GetRequiredService<T>() where T : notnull
+    {
+        if (_provider is null)
+        {
+            throw new InvalidOperationException("Service provider is not configured. Call ServiceHelper.Configure during app startup.");
+        }
+
+        return _provider.GetRequiredService<T>();
+    }
+
+    public static T? GetService<T>()
+    {
+        return _provider?.GetService<T>();
+    }
+}

--- a/CashRegisterMaui/MauiProgram.cs
+++ b/CashRegisterMaui/MauiProgram.cs
@@ -1,0 +1,62 @@
+using System.IO;
+using CashRegisterMaui.Data;
+using CashRegisterMaui.Helpers;
+using CashRegisterMaui.Services;
+using CashRegisterMaui.ViewModels;
+using CashRegisterMaui.Views;
+using CommunityToolkit.Maui;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Maui.Storage;
+using SQLitePCL;
+
+namespace CashRegisterMaui;
+
+public static class MauiProgram
+{
+    public static MauiApp CreateMauiApp()
+    {
+        var builder = MauiApp.CreateBuilder();
+        builder
+            .UseMauiApp<App>()
+            .UseMauiCommunityToolkit();
+
+        SQLitePCL.Batteries_V2.Init();
+
+        var dbPath = Path.Combine(FileSystem.AppDataDirectory, "cashregister.db");
+        builder.Services.AddDbContextFactory<AppDbContext>(options =>
+        {
+            options.UseSqlite($"Data Source={dbPath}");
+        });
+
+        builder.Services.AddSingleton<IDatabaseInitializer, DatabaseInitializer>();
+        builder.Services.AddSingleton<AppState>();
+        builder.Services.AddScoped<IAuthenticationService, AuthenticationService>();
+        builder.Services.AddScoped<ISessionService, SessionService>();
+        builder.Services.AddScoped<IReportService, ReportService>();
+        builder.Services.AddScoped<IUserService, UserService>();
+
+        builder.Services.AddTransient<LoginViewModel>();
+        builder.Services.AddTransient<UserDashboardViewModel>();
+        builder.Services.AddTransient<AdminDashboardViewModel>();
+
+        builder.Services.AddSingleton<AppShell>();
+        builder.Services.AddTransient<LoginPage>();
+        builder.Services.AddTransient<UserDashboardPage>();
+        builder.Services.AddTransient<AdminDashboardPage>();
+
+#if DEBUG
+        builder.Logging.AddDebug();
+#endif
+
+        var app = builder.Build();
+        ServiceHelper.Configure(app.Services);
+
+        using var scope = app.Services.CreateScope();
+        var initializer = scope.ServiceProvider.GetRequiredService<IDatabaseInitializer>();
+        initializer.InitializeAsync().GetAwaiter().GetResult();
+
+        return app;
+    }
+}

--- a/CashRegisterMaui/Migrations/README.md
+++ b/CashRegisterMaui/Migrations/README.md
@@ -1,0 +1,13 @@
+# Entity Framework Core Migrations
+
+لتوليد الهجرات وتشغيلها استخدم أوامر EF Core المعتادة من داخل مجلد المشروع:
+
+```bash
+# إنشاء الهجرة الأولى
+ dotnet ef migrations add InitialCreate
+
+# تحديث قاعدة البيانات
+ dotnet ef database update
+```
+
+الهجرات تُحفظ داخل هذا المجلد وسيتم تطبيقها تلقائياً عند تشغيل التطبيق بفضل `DatabaseInitializer`.

--- a/CashRegisterMaui/Models/CashSession.cs
+++ b/CashRegisterMaui/Models/CashSession.cs
@@ -1,0 +1,58 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Linq;
+
+namespace CashRegisterMaui.Models;
+
+public class CashSession
+{
+    [Key]
+    public int Id { get; set; }
+
+    [Required]
+    public int UserId { get; set; }
+
+    public User? User { get; set; }
+
+    [Required]
+    public DateTime OpenedAt { get; set; } = DateTime.UtcNow;
+
+    public DateTime? ClosedAt { get; set; }
+
+    [Column(TypeName = "decimal(18,2)")]
+    public decimal OpeningCash { get; set; }
+
+    [Column(TypeName = "decimal(18,2)")]
+    public decimal ClosingCash { get; set; }
+
+    [Column(TypeName = "decimal(18,2)")]
+    public decimal OpeningFlexi { get; set; }
+
+    [Column(TypeName = "decimal(18,2)")]
+    public decimal ClosingFlexi { get; set; }
+
+    [MaxLength(256)]
+    public string? Notes { get; set; }
+
+    public ICollection<Transaction> Transactions { get; set; } = new HashSet<Transaction>();
+
+    public ICollection<FlexiTransaction> FlexiTransactions { get; set; } = new HashSet<FlexiTransaction>();
+
+    [NotMapped]
+    public decimal TotalExpense => Transactions?.Sum(t => t.Amount) ?? 0m;
+
+    [NotMapped]
+    public decimal TotalFlexiAdditions => FlexiTransactions?.Sum(t => t.Amount) ?? 0m;
+
+    [NotMapped]
+    public decimal TotalFlexiPaid => FlexiTransactions?.Where(t => t.IsPaid).Sum(t => t.Amount) ?? 0m;
+
+    [NotMapped]
+    public decimal NetCashDifference => (ClosingCash - OpeningCash) - TotalExpense + TotalFlexiPaid;
+
+    [NotMapped]
+    public decimal FlexiConsumed => TotalFlexiAdditions - ClosingFlexi;
+
+    [NotMapped]
+    public bool IsClosed => ClosedAt.HasValue;
+}

--- a/CashRegisterMaui/Models/DashboardSummary.cs
+++ b/CashRegisterMaui/Models/DashboardSummary.cs
@@ -1,0 +1,11 @@
+namespace CashRegisterMaui.Models;
+
+public class DashboardSummary
+{
+    public decimal TotalExpenses { get; set; }
+    public decimal TotalFlexiAdditions { get; set; }
+    public decimal TotalFlexiPaid { get; set; }
+    public decimal NetCashDifference { get; set; }
+    public decimal FlexiConsumed { get; set; }
+    public decimal Profit { get; set; }
+}

--- a/CashRegisterMaui/Models/FlexiTransaction.cs
+++ b/CashRegisterMaui/Models/FlexiTransaction.cs
@@ -1,0 +1,26 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace CashRegisterMaui.Models;
+
+public class FlexiTransaction
+{
+    [Key]
+    public int Id { get; set; }
+
+    [Required]
+    public int CashSessionId { get; set; }
+
+    public CashSession? CashSession { get; set; }
+
+    [Column(TypeName = "decimal(18,2)")]
+    public decimal Amount { get; set; }
+
+    public bool IsPaid { get; set; }
+
+    [MaxLength(256)]
+    public string? Notes { get; set; }
+
+    [Required]
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/CashRegisterMaui/Models/SessionReport.cs
+++ b/CashRegisterMaui/Models/SessionReport.cs
@@ -1,0 +1,18 @@
+namespace CashRegisterMaui.Models;
+
+public class SessionReport
+{
+    public int SessionId { get; set; }
+    public string UserName { get; set; } = string.Empty;
+    public DateTime OpenedAt { get; set; }
+    public DateTime? ClosedAt { get; set; }
+    public decimal OpeningCash { get; set; }
+    public decimal ClosingCash { get; set; }
+    public decimal OpeningFlexi { get; set; }
+    public decimal ClosingFlexi { get; set; }
+    public decimal TotalExpenses { get; set; }
+    public decimal TotalFlexiAdditions { get; set; }
+    public decimal TotalFlexiPaid { get; set; }
+    public decimal NetCashDifference { get; set; }
+    public decimal FlexiConsumed { get; set; }
+}

--- a/CashRegisterMaui/Models/Transaction.cs
+++ b/CashRegisterMaui/Models/Transaction.cs
@@ -1,0 +1,24 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace CashRegisterMaui.Models;
+
+public class Transaction
+{
+    [Key]
+    public int Id { get; set; }
+
+    [Required]
+    public int CashSessionId { get; set; }
+
+    public CashSession? CashSession { get; set; }
+
+    [Column(TypeName = "decimal(18,2)")]
+    public decimal Amount { get; set; }
+
+    [MaxLength(256)]
+    public string? Description { get; set; }
+
+    [Required]
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/CashRegisterMaui/Models/User.cs
+++ b/CashRegisterMaui/Models/User.cs
@@ -1,0 +1,30 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace CashRegisterMaui.Models;
+
+public class User
+{
+    [Key]
+    public int Id { get; set; }
+
+    [Required]
+    [MaxLength(64)]
+    public string Username { get; set; } = string.Empty;
+
+    [Required]
+    public string PasswordHash { get; set; } = string.Empty;
+
+    [Required]
+    public UserRole Role { get; set; } = UserRole.User;
+
+    [MaxLength(128)]
+    public string? FullName { get; set; }
+
+    public bool IsActive { get; set; } = true;
+
+    public ICollection<CashSession> CashSessions { get; set; } = new HashSet<CashSession>();
+
+    [NotMapped]
+    public string DisplayName => string.IsNullOrWhiteSpace(FullName) ? Username : FullName;
+}

--- a/CashRegisterMaui/Models/UserRole.cs
+++ b/CashRegisterMaui/Models/UserRole.cs
@@ -1,0 +1,7 @@
+namespace CashRegisterMaui.Models;
+
+public enum UserRole
+{
+    User = 0,
+    Admin = 1
+}

--- a/CashRegisterMaui/Platforms/Android/MainActivity.cs
+++ b/CashRegisterMaui/Platforms/Android/MainActivity.cs
@@ -1,0 +1,10 @@
+using Android.App;
+using Android.Content.PM;
+using Android.OS;
+
+namespace CashRegisterMaui;
+
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+public class MainActivity : MauiAppCompatActivity
+{
+}

--- a/CashRegisterMaui/Platforms/Android/MainApplication.cs
+++ b/CashRegisterMaui/Platforms/Android/MainApplication.cs
@@ -1,0 +1,16 @@
+using System;
+using Android.App;
+using Android.Runtime;
+using Microsoft.Maui;
+
+namespace CashRegisterMaui;
+
+[Application]
+public class MainApplication : MauiApplication
+{
+    public MainApplication(IntPtr handle, JniHandleOwnership ownership) : base(handle, ownership)
+    {
+    }
+
+    protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+}

--- a/CashRegisterMaui/Platforms/MacCatalyst/AppDelegate.cs
+++ b/CashRegisterMaui/Platforms/MacCatalyst/AppDelegate.cs
@@ -1,0 +1,9 @@
+using Foundation;
+
+namespace CashRegisterMaui;
+
+[Register("AppDelegate")]
+public class AppDelegate : MauiUIApplicationDelegate
+{
+    protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+}

--- a/CashRegisterMaui/Platforms/MacCatalyst/Program.cs
+++ b/CashRegisterMaui/Platforms/MacCatalyst/Program.cs
@@ -1,0 +1,12 @@
+using ObjCRuntime;
+using UIKit;
+
+namespace CashRegisterMaui;
+
+public class Program
+{
+    static void Main(string[] args)
+    {
+        UIApplication.Main(args, null, typeof(AppDelegate));
+    }
+}

--- a/CashRegisterMaui/Platforms/Tizen/Main.cs
+++ b/CashRegisterMaui/Platforms/Tizen/Main.cs
@@ -1,0 +1,15 @@
+using Microsoft.Maui;
+using Microsoft.Maui.Hosting;
+
+namespace CashRegisterMaui;
+
+public class Program : MauiApplication
+{
+    protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+
+    static void Main(string[] args)
+    {
+        var app = new Program();
+        app.Run(args);
+    }
+}

--- a/CashRegisterMaui/Platforms/iOS/AppDelegate.cs
+++ b/CashRegisterMaui/Platforms/iOS/AppDelegate.cs
@@ -1,0 +1,9 @@
+using Foundation;
+
+namespace CashRegisterMaui;
+
+[Register("AppDelegate")]
+public class AppDelegate : MauiUIApplicationDelegate
+{
+    protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+}

--- a/CashRegisterMaui/Platforms/iOS/Program.cs
+++ b/CashRegisterMaui/Platforms/iOS/Program.cs
@@ -1,0 +1,12 @@
+using ObjCRuntime;
+using UIKit;
+
+namespace CashRegisterMaui;
+
+public class Program
+{
+    static void Main(string[] args)
+    {
+        UIApplication.Main(args, null, typeof(AppDelegate));
+    }
+}

--- a/CashRegisterMaui/Program.cs
+++ b/CashRegisterMaui/Program.cs
@@ -1,0 +1,14 @@
+using Microsoft.Maui;
+
+namespace CashRegisterMaui;
+
+public class Program : MauiApplication
+{
+    protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+
+    static void Main(string[] args)
+    {
+        var app = new Program();
+        app.Run(args);
+    }
+}

--- a/CashRegisterMaui/Resources/AppIcon/appicon.svg
+++ b/CashRegisterMaui/Resources/AppIcon/appicon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="grad" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0" stop-color="#512BD4" />
+      <stop offset="1" stop-color="#8547F2" />
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="96" fill="url(#grad)" />
+  <g fill="#fff" transform="translate(128 120)">
+    <path d="M184 32H80a48 48 0 0 0-48 48v96a48 48 0 0 0 48 48h120a24 24 0 1 0 0-48H96a24 24 0 0 1 0-48h120a72 72 0 0 0 0-144Z" opacity=".9"/>
+    <path d="M160 240a24 24 0 0 0 0 48h64v32a24 24 0 0 0 48 0v-32h32a24 24 0 0 0 0-48h-32v-96a24 24 0 0 0-48 0v96Z"/>
+  </g>
+</svg>

--- a/CashRegisterMaui/Resources/Splash/splash.svg
+++ b/CashRegisterMaui/Resources/Splash/splash.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <rect width="512" height="512" fill="#512BD4" />
+  <g fill="#fff" font-family="Segoe UI" font-size="72" font-weight="700" text-anchor="middle">
+    <text x="50%" y="50%">Cash</text>
+    <text x="50%" y="60%">Register</text>
+  </g>
+</svg>

--- a/CashRegisterMaui/Resources/Styles/Colors.xaml
+++ b/CashRegisterMaui/Resources/Styles/Colors.xaml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2009/xaml"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+    <Color x:Key="PrimaryColor">#512BD4</Color>
+    <Color x:Key="SecondaryColor">#8547F2</Color>
+    <Color x:Key="SurfaceColor">#F5F5FB</Color>
+    <Color x:Key="CardColor">#FFFFFFFF</Color>
+    <Color x:Key="PrimaryTextColor">#1F1B24</Color>
+    <Color x:Key="SecondaryTextColor">#5E5873</Color>
+</ResourceDictionary>

--- a/CashRegisterMaui/Resources/Styles/Styles.xaml
+++ b/CashRegisterMaui/Resources/Styles/Styles.xaml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2009/xaml"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                    xmlns:converters="clr-namespace:CashRegisterMaui.Converters">
+    <converters:StringNotEmptyConverter x:Key="StringNotEmptyConverter" />
+
+    <SolidColorBrush x:Key="PrimaryBrush" Color="{StaticResource PrimaryColor}" />
+    <SolidColorBrush x:Key="SecondaryBrush" Color="{StaticResource SecondaryColor}" />
+    <SolidColorBrush x:Key="SurfaceBrush" Color="{StaticResource SurfaceColor}" />
+    <SolidColorBrush x:Key="CardBackgroundColor" Color="{StaticResource CardColor}" />
+    <SolidColorBrush x:Key="PrimaryTextBrush" Color="{StaticResource PrimaryTextColor}" />
+    <SolidColorBrush x:Key="SecondaryTextBrush" Color="{StaticResource SecondaryTextColor}" />
+
+    <Style TargetType="ContentPage">
+        <Setter Property="BackgroundColor" Value="{StaticResource SurfaceColor}" />
+    </Style>
+
+    <Style TargetType="Label">
+        <Setter Property="TextColor" Value="{StaticResource PrimaryTextColor}" />
+    </Style>
+
+    <Style TargetType="Button">
+        <Setter Property="BackgroundColor" Value="{StaticResource PrimaryColor}" />
+        <Setter Property="TextColor" Value="White" />
+        <Setter Property="CornerRadius" Value="12" />
+        <Setter Property="HeightRequest" Value="48" />
+    </Style>
+
+    <Style TargetType="Entry">
+        <Setter Property="BackgroundColor" Value="White" />
+        <Setter Property="TextColor" Value="{StaticResource PrimaryTextColor}" />
+        <Setter Property="PlaceholderColor" Value="{StaticResource SecondaryTextColor}" />
+    </Style>
+
+    <Style TargetType="Frame">
+        <Setter Property="CornerRadius" Value="16" />
+        <Setter Property="BackgroundColor" Value="{StaticResource CardBackgroundColor}" />
+        <Setter Property="HasShadow" Value="True" />
+    </Style>
+</ResourceDictionary>

--- a/CashRegisterMaui/Services/AppState.cs
+++ b/CashRegisterMaui/Services/AppState.cs
@@ -1,0 +1,8 @@
+using CashRegisterMaui.Models;
+
+namespace CashRegisterMaui.Services;
+
+public class AppState
+{
+    public User? CurrentUser { get; set; }
+}

--- a/CashRegisterMaui/Services/AuthenticationService.cs
+++ b/CashRegisterMaui/Services/AuthenticationService.cs
@@ -1,0 +1,24 @@
+using CashRegisterMaui.Data;
+using CashRegisterMaui.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace CashRegisterMaui.Services;
+
+public class AuthenticationService : IAuthenticationService
+{
+    private readonly IDbContextFactory<AppDbContext> _contextFactory;
+
+    public AuthenticationService(IDbContextFactory<AppDbContext> contextFactory)
+    {
+        _contextFactory = contextFactory;
+    }
+
+    public async Task<User?> AuthenticateAsync(string username, string password, CancellationToken cancellationToken = default)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+        var passwordHash = AppDbContext.HashPassword(password);
+        return await context.Users.FirstOrDefaultAsync(
+            user => user.Username == username && user.PasswordHash == passwordHash && user.IsActive,
+            cancellationToken);
+    }
+}

--- a/CashRegisterMaui/Services/DatabaseInitializer.cs
+++ b/CashRegisterMaui/Services/DatabaseInitializer.cs
@@ -1,0 +1,25 @@
+using CashRegisterMaui.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace CashRegisterMaui.Services;
+
+public interface IDatabaseInitializer
+{
+    Task InitializeAsync();
+}
+
+public class DatabaseInitializer : IDatabaseInitializer
+{
+    private readonly IDbContextFactory<AppDbContext> _contextFactory;
+
+    public DatabaseInitializer(IDbContextFactory<AppDbContext> contextFactory)
+    {
+        _contextFactory = contextFactory;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync();
+        await context.Database.MigrateAsync();
+    }
+}

--- a/CashRegisterMaui/Services/IAuthenticationService.cs
+++ b/CashRegisterMaui/Services/IAuthenticationService.cs
@@ -1,0 +1,8 @@
+using CashRegisterMaui.Models;
+
+namespace CashRegisterMaui.Services;
+
+public interface IAuthenticationService
+{
+    Task<User?> AuthenticateAsync(string username, string password, CancellationToken cancellationToken = default);
+}

--- a/CashRegisterMaui/Services/IReportService.cs
+++ b/CashRegisterMaui/Services/IReportService.cs
@@ -1,0 +1,12 @@
+using CashRegisterMaui.Models;
+
+namespace CashRegisterMaui.Services;
+
+public interface IReportService
+{
+    Task<DashboardSummary> GetUserSummaryAsync(int userId, DateTime? from = null, DateTime? to = null, CancellationToken cancellationToken = default);
+    Task<DashboardSummary> GetAdminSummaryAsync(DateTime? from = null, DateTime? to = null, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<SessionReport>> GetSessionReportsAsync(int? userId = null, DateTime? from = null, DateTime? to = null, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<FlexiTransaction>> GetFlexiTransactionsAsync(bool? isPaid = null, DateTime? from = null, DateTime? to = null, CancellationToken cancellationToken = default);
+    Task<IDictionary<string, decimal>> GetFlexiConsumptionByUserAsync(DateTime? from = null, DateTime? to = null, CancellationToken cancellationToken = default);
+}

--- a/CashRegisterMaui/Services/ISessionService.cs
+++ b/CashRegisterMaui/Services/ISessionService.cs
@@ -1,0 +1,13 @@
+using CashRegisterMaui.Models;
+
+namespace CashRegisterMaui.Services;
+
+public interface ISessionService
+{
+    Task<CashSession?> GetActiveSessionAsync(int userId, CancellationToken cancellationToken = default);
+    Task<CashSession> OpenSessionAsync(int userId, decimal openingCash, decimal openingFlexi, string? notes = null, CancellationToken cancellationToken = default);
+    Task CloseSessionAsync(int sessionId, decimal closingCash, decimal closingFlexi, string? notes = null, CancellationToken cancellationToken = default);
+    Task<Transaction> AddExpenseAsync(int sessionId, decimal amount, string? description, CancellationToken cancellationToken = default);
+    Task<FlexiTransaction> AddFlexiAsync(int sessionId, decimal amount, bool isPaid, string? notes, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<CashSession>> GetSessionsAsync(int? userId = null, DateTime? from = null, DateTime? to = null, CancellationToken cancellationToken = default);
+}

--- a/CashRegisterMaui/Services/IUserService.cs
+++ b/CashRegisterMaui/Services/IUserService.cs
@@ -1,0 +1,11 @@
+using CashRegisterMaui.Models;
+
+namespace CashRegisterMaui.Services;
+
+public interface IUserService
+{
+    Task<IReadOnlyList<User>> GetUsersAsync(CancellationToken cancellationToken = default);
+    Task<User> AddUserAsync(string username, string password, UserRole role, string? fullName = null, CancellationToken cancellationToken = default);
+    Task UpdateUserAsync(int userId, string? password = null, UserRole? role = null, string? fullName = null, bool? isActive = null, CancellationToken cancellationToken = default);
+    Task DeleteUserAsync(int userId, CancellationToken cancellationToken = default);
+}

--- a/CashRegisterMaui/Services/ReportService.cs
+++ b/CashRegisterMaui/Services/ReportService.cs
@@ -1,0 +1,134 @@
+using System.Collections.Generic;
+using System.Linq;
+using CashRegisterMaui.Data;
+using CashRegisterMaui.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace CashRegisterMaui.Services;
+
+public class ReportService : IReportService
+{
+    private readonly IDbContextFactory<AppDbContext> _contextFactory;
+
+    public ReportService(IDbContextFactory<AppDbContext> contextFactory)
+    {
+        _contextFactory = contextFactory;
+    }
+
+    public async Task<DashboardSummary> GetUserSummaryAsync(int userId, DateTime? from = null, DateTime? to = null, CancellationToken cancellationToken = default)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+        var sessions = await BuildSessionQuery(context, from, to)
+            .Where(session => session.UserId == userId)
+            .ToListAsync(cancellationToken);
+        return BuildSummary(sessions);
+    }
+
+    public async Task<DashboardSummary> GetAdminSummaryAsync(DateTime? from = null, DateTime? to = null, CancellationToken cancellationToken = default)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+        var sessions = await BuildSessionQuery(context, from, to).ToListAsync(cancellationToken);
+        return BuildSummary(sessions);
+    }
+
+    public async Task<IReadOnlyList<SessionReport>> GetSessionReportsAsync(int? userId = null, DateTime? from = null, DateTime? to = null, CancellationToken cancellationToken = default)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+        var query = BuildSessionQuery(context, from, to);
+
+        if (userId.HasValue)
+        {
+            query = query.Where(session => session.UserId == userId.Value);
+        }
+
+        var sessions = await query.ToListAsync(cancellationToken);
+        return sessions.Select(session => new SessionReport
+        {
+            SessionId = session.Id,
+            UserName = session.User?.DisplayName ?? session.User?.Username ?? "",
+            OpenedAt = session.OpenedAt,
+            ClosedAt = session.ClosedAt,
+            OpeningCash = session.OpeningCash,
+            ClosingCash = session.ClosingCash,
+            OpeningFlexi = session.OpeningFlexi,
+            ClosingFlexi = session.ClosingFlexi,
+            TotalExpenses = session.TotalExpense,
+            TotalFlexiAdditions = session.TotalFlexiAdditions,
+            TotalFlexiPaid = session.TotalFlexiPaid,
+            NetCashDifference = session.NetCashDifference,
+            FlexiConsumed = session.FlexiConsumed
+        }).ToList();
+    }
+
+    public async Task<IReadOnlyList<FlexiTransaction>> GetFlexiTransactionsAsync(bool? isPaid = null, DateTime? from = null, DateTime? to = null, CancellationToken cancellationToken = default)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+        var query = context.FlexiTransactions.AsQueryable();
+
+        if (isPaid.HasValue)
+        {
+            query = query.Where(f => f.IsPaid == isPaid.Value);
+        }
+
+        if (from.HasValue)
+        {
+            query = query.Where(f => f.CreatedAt >= from.Value);
+        }
+
+        if (to.HasValue)
+        {
+            query = query.Where(f => f.CreatedAt <= to.Value);
+        }
+
+        return await query.OrderByDescending(f => f.CreatedAt).ToListAsync(cancellationToken);
+    }
+
+    public async Task<IDictionary<string, decimal>> GetFlexiConsumptionByUserAsync(DateTime? from = null, DateTime? to = null, CancellationToken cancellationToken = default)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+        var sessions = await BuildSessionQuery(context, from, to).ToListAsync(cancellationToken);
+
+        return sessions
+            .GroupBy(session => session.User?.DisplayName ?? session.User?.Username ?? "Unknown")
+            .ToDictionary(group => group.Key, group => group.Sum(session => session.FlexiConsumed));
+    }
+
+    private static IQueryable<CashSession> BuildSessionQuery(AppDbContext context, DateTime? from, DateTime? to)
+    {
+        var query = context.CashSessions
+            .Include(session => session.User)
+            .Include(session => session.Transactions)
+            .Include(session => session.FlexiTransactions)
+            .AsQueryable();
+
+        if (from.HasValue)
+        {
+            query = query.Where(session => session.OpenedAt >= from.Value);
+        }
+
+        if (to.HasValue)
+        {
+            query = query.Where(session => session.OpenedAt <= to.Value);
+        }
+
+        return query;
+    }
+
+    private static DashboardSummary BuildSummary(IEnumerable<CashSession> sessions)
+    {
+        var totalExpenses = sessions.Sum(session => session.TotalExpense);
+        var totalFlexiAdditions = sessions.Sum(session => session.TotalFlexiAdditions);
+        var totalFlexiPaid = sessions.Sum(session => session.TotalFlexiPaid);
+        var netCashDifference = sessions.Sum(session => session.NetCashDifference);
+        var flexiConsumed = sessions.Sum(session => session.FlexiConsumed);
+        return new DashboardSummary
+        {
+            TotalExpenses = totalExpenses,
+            TotalFlexiAdditions = totalFlexiAdditions,
+            TotalFlexiPaid = totalFlexiPaid,
+            NetCashDifference = netCashDifference,
+            FlexiConsumed = flexiConsumed,
+            Profit = netCashDifference + totalFlexiPaid - totalExpenses
+        };
+    }
+}

--- a/CashRegisterMaui/Services/SessionService.cs
+++ b/CashRegisterMaui/Services/SessionService.cs
@@ -1,0 +1,137 @@
+using CashRegisterMaui.Data;
+using CashRegisterMaui.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace CashRegisterMaui.Services;
+
+public class SessionService : ISessionService
+{
+    private readonly IDbContextFactory<AppDbContext> _contextFactory;
+
+    public SessionService(IDbContextFactory<AppDbContext> contextFactory)
+    {
+        _contextFactory = contextFactory;
+    }
+
+    public async Task<CashSession?> GetActiveSessionAsync(int userId, CancellationToken cancellationToken = default)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+        return await context.CashSessions
+            .Include(cs => cs.Transactions)
+            .Include(cs => cs.FlexiTransactions)
+            .Where(cs => cs.UserId == userId && cs.ClosedAt == null)
+            .OrderByDescending(cs => cs.OpenedAt)
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+
+    public async Task<CashSession> OpenSessionAsync(int userId, decimal openingCash, decimal openingFlexi, string? notes = null, CancellationToken cancellationToken = default)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+        var existing = await context.CashSessions.AnyAsync(cs => cs.UserId == userId && cs.ClosedAt == null, cancellationToken);
+        if (existing)
+        {
+            throw new InvalidOperationException("There is already an open session for this user.");
+        }
+
+        var session = new CashSession
+        {
+            UserId = userId,
+            OpeningCash = openingCash,
+            ClosingCash = openingCash,
+            OpeningFlexi = openingFlexi,
+            ClosingFlexi = openingFlexi,
+            Notes = notes,
+            OpenedAt = DateTime.UtcNow
+        };
+
+        await context.CashSessions.AddAsync(session, cancellationToken);
+        await context.SaveChangesAsync(cancellationToken);
+        return session;
+    }
+
+    public async Task CloseSessionAsync(int sessionId, decimal closingCash, decimal closingFlexi, string? notes = null, CancellationToken cancellationToken = default)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+        var session = await context.CashSessions.FirstOrDefaultAsync(cs => cs.Id == sessionId, cancellationToken);
+        if (session is null)
+        {
+            throw new InvalidOperationException("Session not found.");
+        }
+
+        session.ClosingCash = closingCash;
+        session.ClosingFlexi = closingFlexi;
+        session.Notes = notes ?? session.Notes;
+        session.ClosedAt = DateTime.UtcNow;
+        await context.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task<Transaction> AddExpenseAsync(int sessionId, decimal amount, string? description, CancellationToken cancellationToken = default)
+    {
+        if (amount < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(amount));
+        }
+
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+        var transaction = new Transaction
+        {
+            CashSessionId = sessionId,
+            Amount = amount,
+            Description = description,
+            CreatedAt = DateTime.UtcNow
+        };
+
+        await context.Transactions.AddAsync(transaction, cancellationToken);
+        await context.SaveChangesAsync(cancellationToken);
+        return transaction;
+    }
+
+    public async Task<FlexiTransaction> AddFlexiAsync(int sessionId, decimal amount, bool isPaid, string? notes, CancellationToken cancellationToken = default)
+    {
+        if (amount < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(amount));
+        }
+
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+        var flexi = new FlexiTransaction
+        {
+            CashSessionId = sessionId,
+            Amount = amount,
+            IsPaid = isPaid,
+            Notes = notes,
+            CreatedAt = DateTime.UtcNow
+        };
+
+        await context.FlexiTransactions.AddAsync(flexi, cancellationToken);
+        await context.SaveChangesAsync(cancellationToken);
+        return flexi;
+    }
+
+    public async Task<IReadOnlyList<CashSession>> GetSessionsAsync(int? userId = null, DateTime? from = null, DateTime? to = null, CancellationToken cancellationToken = default)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+        var query = context.CashSessions
+            .Include(cs => cs.User)
+            .Include(cs => cs.Transactions)
+            .Include(cs => cs.FlexiTransactions)
+            .AsQueryable();
+
+        if (userId.HasValue)
+        {
+            query = query.Where(cs => cs.UserId == userId.Value);
+        }
+
+        if (from.HasValue)
+        {
+            query = query.Where(cs => cs.OpenedAt >= from.Value);
+        }
+
+        if (to.HasValue)
+        {
+            query = query.Where(cs => cs.OpenedAt <= to.Value);
+        }
+
+        return await query.OrderByDescending(cs => cs.OpenedAt).ToListAsync(cancellationToken);
+    }
+}

--- a/CashRegisterMaui/Services/UserService.cs
+++ b/CashRegisterMaui/Services/UserService.cs
@@ -1,0 +1,83 @@
+using System.Linq;
+using CashRegisterMaui.Data;
+using CashRegisterMaui.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace CashRegisterMaui.Services;
+
+public class UserService : IUserService
+{
+    private readonly IDbContextFactory<AppDbContext> _contextFactory;
+
+    public UserService(IDbContextFactory<AppDbContext> contextFactory)
+    {
+        _contextFactory = contextFactory;
+    }
+
+    public async Task<IReadOnlyList<User>> GetUsersAsync(CancellationToken cancellationToken = default)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+        return await context.Users.OrderBy(user => user.Username).ToListAsync(cancellationToken);
+    }
+
+    public async Task<User> AddUserAsync(string username, string password, UserRole role, string? fullName = null, CancellationToken cancellationToken = default)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+        var user = new User
+        {
+            Username = username,
+            PasswordHash = AppDbContext.HashPassword(password),
+            Role = role,
+            FullName = fullName,
+            IsActive = true
+        };
+        await context.Users.AddAsync(user, cancellationToken);
+        await context.SaveChangesAsync(cancellationToken);
+        return user;
+    }
+
+    public async Task UpdateUserAsync(int userId, string? password = null, UserRole? role = null, string? fullName = null, bool? isActive = null, CancellationToken cancellationToken = default)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+        var user = await context.Users.FirstOrDefaultAsync(u => u.Id == userId, cancellationToken);
+        if (user is null)
+        {
+            throw new InvalidOperationException("User not found");
+        }
+
+        if (!string.IsNullOrWhiteSpace(password))
+        {
+            user.PasswordHash = AppDbContext.HashPassword(password);
+        }
+
+        if (role.HasValue)
+        {
+            user.Role = role.Value;
+        }
+
+        if (fullName is not null)
+        {
+            user.FullName = fullName;
+        }
+
+        if (isActive.HasValue)
+        {
+            user.IsActive = isActive.Value;
+        }
+
+        await context.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task DeleteUserAsync(int userId, CancellationToken cancellationToken = default)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+        var user = await context.Users.FirstOrDefaultAsync(u => u.Id == userId, cancellationToken);
+        if (user is null)
+        {
+            return;
+        }
+
+        context.Users.Remove(user);
+        await context.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/CashRegisterMaui/ViewModels/AdminDashboardViewModel.cs
+++ b/CashRegisterMaui/ViewModels/AdminDashboardViewModel.cs
@@ -1,0 +1,199 @@
+using System.Collections.ObjectModel;
+using System.Linq;
+using CashRegisterMaui.Models;
+using CashRegisterMaui.Services;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using LiveChartsCore;
+using LiveChartsCore.SkiaSharpView;
+using LiveChartsCore.SkiaSharpView.Painting;
+using SkiaSharp;
+
+namespace CashRegisterMaui.ViewModels;
+
+public partial class AdminDashboardViewModel : ViewModelBase
+{
+    private readonly IReportService _reportService;
+    private readonly IUserService _userService;
+
+    public AdminDashboardViewModel(IReportService reportService, IUserService userService)
+    {
+        _reportService = reportService;
+        _userService = userService;
+        Title = "لوحة المشرف";
+    }
+
+    [ObservableProperty]
+    private DashboardSummary summary = new();
+
+    [ObservableProperty]
+    private string? statusMessage;
+
+    [ObservableProperty]
+    private User? selectedUser;
+
+    [ObservableProperty]
+    private string newUsername = string.Empty;
+
+    [ObservableProperty]
+    private string newFullName = string.Empty;
+
+    [ObservableProperty]
+    private string newPassword = string.Empty;
+
+    [ObservableProperty]
+    private bool newIsAdmin;
+
+    [ObservableProperty]
+    private bool newIsActive = true;
+
+    [ObservableProperty]
+    private ISeries[] flexiSeries = Array.Empty<ISeries>();
+
+    [ObservableProperty]
+    private Axis[] flexiXAxis = Array.Empty<Axis>();
+
+    public ObservableCollection<User> Users { get; } = new();
+
+    public ObservableCollection<SessionReport> SessionReports { get; } = new();
+
+    [RelayCommand]
+    public async Task LoadAsync()
+    {
+        try
+        {
+            IsBusy = true;
+            StatusMessage = string.Empty;
+            await RefreshAsync();
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    [RelayCommand]
+    private async Task AddUserAsync()
+    {
+        if (string.IsNullOrWhiteSpace(NewUsername) || string.IsNullOrWhiteSpace(NewPassword))
+        {
+            StatusMessage = "الرجاء إدخال اسم مستخدم وكلمة مرور";
+            return;
+        }
+
+        var role = NewIsAdmin ? UserRole.Admin : UserRole.User;
+        await _userService.AddUserAsync(NewUsername.Trim(), NewPassword, role, NewFullName);
+        StatusMessage = "تمت إضافة المستخدم";
+        await RefreshUsersAsync();
+        ClearForm();
+    }
+
+    [RelayCommand]
+    private async Task UpdateUserAsync()
+    {
+        if (SelectedUser is null)
+        {
+            StatusMessage = "الرجاء اختيار مستخدم";
+            return;
+        }
+
+        var role = NewIsAdmin ? UserRole.Admin : UserRole.User;
+        await _userService.UpdateUserAsync(SelectedUser.Id, string.IsNullOrWhiteSpace(NewPassword) ? null : NewPassword, role, NewFullName, NewIsActive);
+        StatusMessage = "تم تحديث بيانات المستخدم";
+        await RefreshUsersAsync();
+    }
+
+    [RelayCommand]
+    private async Task DeleteUserAsync()
+    {
+        if (SelectedUser is null)
+        {
+            StatusMessage = "الرجاء اختيار مستخدم";
+            return;
+        }
+
+        await _userService.DeleteUserAsync(SelectedUser.Id);
+        StatusMessage = "تم حذف المستخدم";
+        await RefreshUsersAsync();
+        ClearForm();
+    }
+
+    [RelayCommand]
+    private async Task RefreshAsync()
+    {
+        Summary = await _reportService.GetAdminSummaryAsync();
+        await RefreshUsersAsync();
+        await RefreshSessionsAsync();
+        await BuildFlexiChartAsync();
+    }
+
+    private async Task RefreshUsersAsync()
+    {
+        var users = await _userService.GetUsersAsync();
+        Users.Clear();
+        foreach (var user in users)
+        {
+            Users.Add(user);
+        }
+    }
+
+    private async Task RefreshSessionsAsync()
+    {
+        var reports = await _reportService.GetSessionReportsAsync();
+        SessionReports.Clear();
+        foreach (var report in reports.Take(20))
+        {
+            SessionReports.Add(report);
+        }
+    }
+
+    private async Task BuildFlexiChartAsync()
+    {
+        var chartData = await _reportService.GetFlexiConsumptionByUserAsync();
+        var ordered = chartData.OrderByDescending(item => item.Value).ToList();
+        var labels = ordered.Select(item => item.Key).ToArray();
+        FlexiSeries = new ISeries[]
+        {
+            new ColumnSeries<decimal>
+            {
+                Values = ordered.Select(item => item.Value).ToArray(),
+                Name = "الفليكسي المستهلك",
+                Fill = new SolidColorPaint(SKColors.DeepSkyBlue)
+            }
+        };
+        FlexiXAxis = new[]
+        {
+            new Axis
+            {
+                Labels = labels,
+                LabelsRotation = -45,
+                LabelsPaint = new SolidColorPaint(SKColors.Gray) { SKTypeface = SKTypeface.Default },
+                TextSize = 14
+            }
+        };
+    }
+
+    partial void OnSelectedUserChanged(User? value)
+    {
+        if (value is null)
+        {
+            return;
+        }
+
+        NewUsername = value.Username;
+        NewFullName = value.FullName ?? string.Empty;
+        NewIsAdmin = value.Role == UserRole.Admin;
+        NewIsActive = value.IsActive;
+        NewPassword = string.Empty;
+    }
+
+    private void ClearForm()
+    {
+        NewUsername = string.Empty;
+        NewFullName = string.Empty;
+        NewPassword = string.Empty;
+        NewIsAdmin = false;
+        NewIsActive = true;
+        SelectedUser = null;
+    }
+}

--- a/CashRegisterMaui/ViewModels/LoginViewModel.cs
+++ b/CashRegisterMaui/ViewModels/LoginViewModel.cs
@@ -1,0 +1,63 @@
+using CashRegisterMaui.Models;
+using CashRegisterMaui.Services;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Microsoft.Maui.ApplicationModel;
+
+namespace CashRegisterMaui.ViewModels;
+
+public partial class LoginViewModel : ViewModelBase
+{
+    private readonly IAuthenticationService _authenticationService;
+    private readonly AppState _appState;
+
+    public LoginViewModel(IAuthenticationService authenticationService, AppState appState)
+    {
+        _authenticationService = authenticationService;
+        _appState = appState;
+        Title = "تسجيل الدخول";
+    }
+
+    [ObservableProperty]
+    private string username = string.Empty;
+
+    [ObservableProperty]
+    private string password = string.Empty;
+
+    [ObservableProperty]
+    private string errorMessage = string.Empty;
+
+    [RelayCommand]
+    private async Task LoginAsync()
+    {
+        if (IsBusy)
+        {
+            return;
+        }
+
+        try
+        {
+            IsBusy = true;
+            ErrorMessage = string.Empty;
+            var user = await _authenticationService.AuthenticateAsync(Username.Trim(), Password);
+            if (user is null)
+            {
+                ErrorMessage = "بيانات الدخول غير صحيحة";
+                return;
+            }
+
+            _appState.CurrentUser = user;
+            var route = user.Role == UserRole.Admin ? "//AdminDashboardPage" : "//UserDashboardPage";
+            await MainThread.InvokeOnMainThreadAsync(() => Shell.Current.GoToAsync(route));
+        }
+        catch (Exception ex)
+        {
+            ErrorMessage = ex.Message;
+        }
+        finally
+        {
+            IsBusy = false;
+            Password = string.Empty;
+        }
+    }
+}

--- a/CashRegisterMaui/ViewModels/UserDashboardViewModel.cs
+++ b/CashRegisterMaui/ViewModels/UserDashboardViewModel.cs
@@ -1,0 +1,183 @@
+using System.Collections.ObjectModel;
+using System.Linq;
+using CashRegisterMaui.Models;
+using CashRegisterMaui.Services;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace CashRegisterMaui.ViewModels;
+
+public partial class UserDashboardViewModel : ViewModelBase
+{
+    private readonly AppState _appState;
+    private readonly ISessionService _sessionService;
+    private readonly IReportService _reportService;
+
+    public UserDashboardViewModel(AppState appState, ISessionService sessionService, IReportService reportService)
+    {
+        _appState = appState;
+        _sessionService = sessionService;
+        _reportService = reportService;
+        Title = "لوحة المستخدم";
+    }
+
+    [ObservableProperty]
+    private CashSession? currentSession;
+
+    [ObservableProperty]
+    private DashboardSummary summary = new();
+
+    [ObservableProperty]
+    private decimal openingCash;
+
+    [ObservableProperty]
+    private decimal openingFlexi;
+
+    [ObservableProperty]
+    private decimal closingCash;
+
+    [ObservableProperty]
+    private decimal closingFlexi;
+
+    [ObservableProperty]
+    private string? sessionNotes;
+
+    [ObservableProperty]
+    private decimal newExpenseAmount;
+
+    [ObservableProperty]
+    private string? newExpenseDescription;
+
+    [ObservableProperty]
+    private decimal newFlexiAmount;
+
+    [ObservableProperty]
+    private bool newFlexiIsPaid;
+
+    [ObservableProperty]
+    private string? newFlexiNotes;
+
+    public ObservableCollection<Transaction> RecentExpenses { get; } = new();
+
+    public ObservableCollection<FlexiTransaction> RecentFlexi { get; } = new();
+
+    public ObservableCollection<CashSession> SessionHistory { get; } = new();
+
+    [RelayCommand]
+    public async Task LoadAsync()
+    {
+        if (_appState.CurrentUser is null)
+        {
+            return;
+        }
+
+        try
+        {
+            IsBusy = true;
+            await RefreshDataAsync(_appState.CurrentUser.Id);
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    [RelayCommand]
+    private async Task OpenSessionAsync()
+    {
+        if (_appState.CurrentUser is null)
+        {
+            return;
+        }
+
+        await _sessionService.OpenSessionAsync(_appState.CurrentUser.Id, OpeningCash, OpeningFlexi, sessionNotes: SessionNotes);
+        await LoadAsync();
+        OpeningCash = 0;
+        OpeningFlexi = 0;
+    }
+
+    [RelayCommand]
+    private async Task CloseSessionAsync()
+    {
+        if (CurrentSession is null)
+        {
+            return;
+        }
+
+        await _sessionService.CloseSessionAsync(CurrentSession.Id, ClosingCash, ClosingFlexi, SessionNotes);
+        await LoadAsync();
+        ClosingCash = 0;
+        ClosingFlexi = 0;
+        SessionNotes = string.Empty;
+    }
+
+    [RelayCommand]
+    private async Task AddExpenseAsync()
+    {
+        if (CurrentSession is null || NewExpenseAmount <= 0)
+        {
+            return;
+        }
+
+        await _sessionService.AddExpenseAsync(CurrentSession.Id, NewExpenseAmount, NewExpenseDescription);
+        NewExpenseAmount = 0;
+        NewExpenseDescription = string.Empty;
+        await LoadAsync();
+    }
+
+    [RelayCommand]
+    private async Task AddFlexiAsync()
+    {
+        if (CurrentSession is null || NewFlexiAmount <= 0)
+        {
+            return;
+        }
+
+        await _sessionService.AddFlexiAsync(CurrentSession.Id, NewFlexiAmount, NewFlexiIsPaid, NewFlexiNotes);
+        NewFlexiAmount = 0;
+        NewFlexiNotes = string.Empty;
+        NewFlexiIsPaid = false;
+        await LoadAsync();
+    }
+
+    private async Task RefreshDataAsync(int userId)
+    {
+        CurrentSession = await _sessionService.GetActiveSessionAsync(userId);
+        if (CurrentSession is not null)
+        {
+            ClosingCash = CurrentSession.ClosingCash;
+            ClosingFlexi = CurrentSession.ClosingFlexi;
+            SessionNotes = CurrentSession.Notes;
+        }
+        else
+        {
+            ClosingCash = 0;
+            ClosingFlexi = 0;
+            SessionNotes = string.Empty;
+        }
+
+        Summary = await _reportService.GetUserSummaryAsync(userId);
+
+        var sessions = await _sessionService.GetSessionsAsync(userId: userId);
+        SessionHistory.Clear();
+        foreach (var session in sessions)
+        {
+            SessionHistory.Add(session);
+        }
+
+        RecentExpenses.Clear();
+        foreach (var transaction in sessions.SelectMany(s => s.Transactions).OrderByDescending(t => t.CreatedAt).Take(10))
+        {
+            RecentExpenses.Add(transaction);
+        }
+
+        RecentFlexi.Clear();
+        foreach (var flexi in sessions.SelectMany(s => s.FlexiTransactions).OrderByDescending(f => f.CreatedAt).Take(10))
+        {
+            RecentFlexi.Add(flexi);
+        }
+
+        OpeningCash = 0;
+        OpeningFlexi = 0;
+    }
+}

--- a/CashRegisterMaui/ViewModels/ViewModelBase.cs
+++ b/CashRegisterMaui/ViewModels/ViewModelBase.cs
@@ -1,0 +1,12 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace CashRegisterMaui.ViewModels;
+
+public partial class ViewModelBase : ObservableObject
+{
+    [ObservableProperty]
+    private bool isBusy;
+
+    [ObservableProperty]
+    private string title = string.Empty;
+}

--- a/CashRegisterMaui/Views/AdminDashboardPage.xaml
+++ b/CashRegisterMaui/Views/AdminDashboardPage.xaml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:lvc="clr-namespace:LiveChartsCore.SkiaSharpView.Maui;assembly=LiveChartsCore.SkiaSharpView.Maui"
+             x:Class="CashRegisterMaui.Views.AdminDashboardPage"
+             Title="{Binding Title}">
+    <ScrollView>
+        <VerticalStackLayout Padding="24" Spacing="16">
+            <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" ColumnSpacing="16" RowSpacing="16">
+                <Frame Grid.Row="0" Grid.Column="0">
+                    <VerticalStackLayout>
+                        <Label Text="إجمالي المصروفات" FontAttributes="Bold" />
+                        <Label Text="{Binding Summary.TotalExpenses, StringFormat='{}{0:C}'}" FontSize="20" />
+                    </VerticalStackLayout>
+                </Frame>
+                <Frame Grid.Row="0" Grid.Column="1">
+                    <VerticalStackLayout>
+                        <Label Text="الفليكسي المستهلك" FontAttributes="Bold" />
+                        <Label Text="{Binding Summary.FlexiConsumed, StringFormat='{}{0:C}'}" FontSize="20" />
+                    </VerticalStackLayout>
+                </Frame>
+                <Frame Grid.Row="1" Grid.Column="0">
+                    <VerticalStackLayout>
+                        <Label Text="الأرباح" FontAttributes="Bold" />
+                        <Label Text="{Binding Summary.Profit, StringFormat='{}{0:C}'}" FontSize="20" />
+                    </VerticalStackLayout>
+                </Frame>
+                <Frame Grid.Row="1" Grid.Column="1">
+                    <VerticalStackLayout>
+                        <Label Text="الفليكسي المدفوع" FontAttributes="Bold" />
+                        <Label Text="{Binding Summary.TotalFlexiPaid, StringFormat='{}{0:C}'}" FontSize="20" />
+                    </VerticalStackLayout>
+                </Frame>
+            </Grid>
+
+            <Frame>
+                <VerticalStackLayout Spacing="12">
+                    <Label Text="إدارة المستخدمين" FontSize="20" FontAttributes="Bold" />
+                    <Entry Placeholder="اسم المستخدم" Text="{Binding NewUsername}" />
+                    <Entry Placeholder="الاسم الكامل" Text="{Binding NewFullName}" />
+                    <Entry Placeholder="كلمة المرور" IsPassword="True" Text="{Binding NewPassword}" />
+                    <HorizontalStackLayout Spacing="12">
+                        <CheckBox IsChecked="{Binding NewIsAdmin}" />
+                        <Label Text="مشرف" VerticalOptions="Center" />
+                        <CheckBox IsChecked="{Binding NewIsActive}" />
+                        <Label Text="مفعل" VerticalOptions="Center" />
+                    </HorizontalStackLayout>
+                    <HorizontalStackLayout Spacing="12">
+                        <Button Text="إضافة" Command="{Binding AddUserCommand}" />
+                        <Button Text="تحديث" Command="{Binding UpdateUserCommand}" />
+                        <Button Text="حذف" Command="{Binding DeleteUserCommand}" />
+                    </HorizontalStackLayout>
+                    <Label Text="{Binding StatusMessage}" TextColor="Green" />
+                </VerticalStackLayout>
+            </Frame>
+
+            <Label Text="قائمة العمال" FontAttributes="Bold" FontSize="20" />
+            <CollectionView ItemsSource="{Binding Users}" SelectionMode="Single" SelectedItem="{Binding SelectedUser}">
+                <CollectionView.ItemTemplate>
+                    <DataTemplate>
+                        <Frame Margin="0,4">
+                            <VerticalStackLayout>
+                                <Label Text="{Binding DisplayName}" />
+                                <Label Text="{Binding Role}" />
+                                <Label Text="{Binding IsActive, StringFormat='مفعل: {0}'}" />
+                            </VerticalStackLayout>
+                        </Frame>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
+
+            <Label Text="تقرير الجلسات" FontAttributes="Bold" FontSize="20" />
+            <CollectionView ItemsSource="{Binding SessionReports}">
+                <CollectionView.ItemTemplate>
+                    <DataTemplate>
+                        <Frame Margin="0,4">
+                            <VerticalStackLayout>
+                                <Label Text="{Binding UserName}" />
+                                <Label Text="{Binding OpenedAt, StringFormat='{0:dd/MM/yyyy}'}" />
+                                <Label Text="{Binding NetCashDifference, StringFormat='الفارق: {0:C}'}" />
+                            </VerticalStackLayout>
+                        </Frame>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
+
+            <Frame>
+                <VerticalStackLayout Spacing="12">
+                    <Label Text="استهلاك الفليكسي حسب المستخدم" FontAttributes="Bold" FontSize="20" />
+                    <lvc:CartesianChart Series="{Binding FlexiSeries}" XAxes="{Binding FlexiXAxis}" />
+                </VerticalStackLayout>
+            </Frame>
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>

--- a/CashRegisterMaui/Views/AdminDashboardPage.xaml.cs
+++ b/CashRegisterMaui/Views/AdminDashboardPage.xaml.cs
@@ -1,0 +1,23 @@
+using CashRegisterMaui.Helpers;
+using CashRegisterMaui.ViewModels;
+using Microsoft.Maui.Controls;
+
+namespace CashRegisterMaui.Views;
+
+public partial class AdminDashboardPage : ContentPage
+{
+    private readonly AdminDashboardViewModel _viewModel;
+
+    public AdminDashboardPage()
+    {
+        InitializeComponent();
+        _viewModel = ServiceHelper.GetRequiredService<AdminDashboardViewModel>();
+        BindingContext = _viewModel;
+    }
+
+    protected override async void OnAppearing()
+    {
+        base.OnAppearing();
+        await _viewModel.LoadAsync();
+    }
+}

--- a/CashRegisterMaui/Views/LoginPage.xaml
+++ b/CashRegisterMaui/Views/LoginPage.xaml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:viewModels="clr-namespace:CashRegisterMaui.ViewModels"
+             x:Class="CashRegisterMaui.Views.LoginPage"
+             BackgroundColor="{StaticResource SurfaceColor}"
+             Title="{Binding Title}">
+    <ScrollView>
+        <VerticalStackLayout Padding="32" Spacing="24" VerticalOptions="Center">
+            <Image Source="appicon.svg" HeightRequest="120" HorizontalOptions="Center" />
+            <Label Text="تسجيل الدخول" FontSize="28" HorizontalOptions="Center" TextColor="{StaticResource PrimaryTextColor}" />
+
+            <Frame Padding="24" BackgroundColor="{StaticResource CardBackgroundColor}" HasShadow="True" CornerRadius="24">
+                <VerticalStackLayout Spacing="16">
+                    <Entry Placeholder="اسم المستخدم" Text="{Binding Username}" />
+                    <Entry Placeholder="كلمة المرور" IsPassword="True" Text="{Binding Password}" />
+                    <Button Text="دخول" Command="{Binding LoginCommand}" />
+                    <Label Text="{Binding ErrorMessage}" TextColor="Red" IsVisible="{Binding ErrorMessage, Converter={StaticResource StringNotEmptyConverter}}" />
+                </VerticalStackLayout>
+            </Frame>
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>

--- a/CashRegisterMaui/Views/LoginPage.xaml.cs
+++ b/CashRegisterMaui/Views/LoginPage.xaml.cs
@@ -1,0 +1,14 @@
+using CashRegisterMaui.Helpers;
+using CashRegisterMaui.ViewModels;
+using Microsoft.Maui.Controls;
+
+namespace CashRegisterMaui.Views;
+
+public partial class LoginPage : ContentPage
+{
+    public LoginPage()
+    {
+        InitializeComponent();
+        BindingContext = ServiceHelper.GetRequiredService<LoginViewModel>();
+    }
+}

--- a/CashRegisterMaui/Views/UserDashboardPage.xaml
+++ b/CashRegisterMaui/Views/UserDashboardPage.xaml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:viewModels="clr-namespace:CashRegisterMaui.ViewModels"
+             x:Class="CashRegisterMaui.Views.UserDashboardPage"
+             Title="{Binding Title}">
+    <ScrollView>
+        <VerticalStackLayout Padding="24" Spacing="16">
+            <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" ColumnSpacing="16" RowSpacing="16">
+                <Frame Grid.Row="0" Grid.Column="0">
+                    <VerticalStackLayout>
+                        <Label Text="إجمالي المصروفات" FontAttributes="Bold" />
+                        <Label Text="{Binding Summary.TotalExpenses, StringFormat='{}{0:C}'}" FontSize="20" />
+                    </VerticalStackLayout>
+                </Frame>
+                <Frame Grid.Row="0" Grid.Column="1">
+                    <VerticalStackLayout>
+                        <Label Text="إجمالي الفليكسي" FontAttributes="Bold" />
+                        <Label Text="{Binding Summary.TotalFlexiAdditions, StringFormat='{}{0:C}'}" FontSize="20" />
+                    </VerticalStackLayout>
+                </Frame>
+                <Frame Grid.Row="1" Grid.Column="0">
+                    <VerticalStackLayout>
+                        <Label Text="الفليكسي المدفوع" FontAttributes="Bold" />
+                        <Label Text="{Binding Summary.TotalFlexiPaid, StringFormat='{}{0:C}'}" FontSize="20" />
+                    </VerticalStackLayout>
+                </Frame>
+                <Frame Grid.Row="1" Grid.Column="1">
+                    <VerticalStackLayout>
+                        <Label Text="الفارق النقدي" FontAttributes="Bold" />
+                        <Label Text="{Binding Summary.NetCashDifference, StringFormat='{}{0:C}'}" FontSize="20" />
+                    </VerticalStackLayout>
+                </Frame>
+            </Grid>
+
+            <Frame>
+                <VerticalStackLayout Spacing="8">
+                    <Label Text="الجلسة الحالية" FontSize="20" />
+                    <Label Text="{Binding CurrentSession.OpenedAt, StringFormat='بدأت في {0:dd/MM/yyyy HH:mm}'}" />
+                    <Label Text="{Binding CurrentSession.IsClosed, StringFormat='مغلقة: {0}'}" />
+                    <Label Text="{Binding CurrentSession.Notes}" />
+                </VerticalStackLayout>
+            </Frame>
+
+            <Frame>
+                <VerticalStackLayout Spacing="8">
+                    <Label Text="فتح/إغلاق الجلسة" FontAttributes="Bold" />
+                    <Grid ColumnDefinitions="*,*" ColumnSpacing="16" RowSpacing="8">
+                        <Entry Grid.Column="0" Placeholder="رصيد بداية نقدي" Keyboard="Numeric" Text="{Binding OpeningCash}" />
+                        <Entry Grid.Column="1" Placeholder="رصيد بداية فليكسي" Keyboard="Numeric" Text="{Binding OpeningFlexi}" />
+                        <Entry Grid.Column="0" Grid.Row="1" Placeholder="رصيد نهاية نقدي" Keyboard="Numeric" Text="{Binding ClosingCash}" />
+                        <Entry Grid.Column="1" Grid.Row="1" Placeholder="رصيد نهاية فليكسي" Keyboard="Numeric" Text="{Binding ClosingFlexi}" />
+                    </Grid>
+                    <Editor Placeholder="ملاحظات" Text="{Binding SessionNotes}" AutoSize="TextChanges" />
+                    <HorizontalStackLayout Spacing="12">
+                        <Button Text="فتح جلسة" Command="{Binding OpenSessionCommand}" />
+                        <Button Text="إغلاق جلسة" Command="{Binding CloseSessionCommand}" />
+                    </HorizontalStackLayout>
+                </VerticalStackLayout>
+            </Frame>
+
+            <Frame>
+                <VerticalStackLayout Spacing="12">
+                    <Label Text="إضافة مصروف" FontAttributes="Bold" />
+                    <Entry Placeholder="المبلغ" Keyboard="Numeric" Text="{Binding NewExpenseAmount}" />
+                    <Entry Placeholder="الوصف" Text="{Binding NewExpenseDescription}" />
+                    <Button Text="حفظ المصروف" Command="{Binding AddExpenseCommand}" />
+                </VerticalStackLayout>
+            </Frame>
+
+            <Frame>
+                <VerticalStackLayout Spacing="12">
+                    <Label Text="إضافة فليكسي" FontAttributes="Bold" />
+                    <Entry Placeholder="المبلغ" Keyboard="Numeric" Text="{Binding NewFlexiAmount}" />
+                    <HorizontalStackLayout Spacing="12" VerticalOptions="Center">
+                        <Label Text="مدفوع؟" VerticalOptions="Center" />
+                        <Switch IsToggled="{Binding NewFlexiIsPaid}">
+                            <Switch.ThumbColor>
+                                <AppThemeColor Light="{StaticResource PrimaryColor}" Dark="{StaticResource SecondaryColor}" />
+                            </Switch.ThumbColor>
+                        </Switch>
+                    </HorizontalStackLayout>
+                    <Entry Placeholder="ملاحظات" Text="{Binding NewFlexiNotes}" />
+                    <Button Text="حفظ الفليكسي" Command="{Binding AddFlexiCommand}" />
+                </VerticalStackLayout>
+            </Frame>
+
+            <Label Text="آخر المصروفات" FontAttributes="Bold" FontSize="20" />
+            <CollectionView ItemsSource="{Binding RecentExpenses}">
+                <CollectionView.ItemTemplate>
+                    <DataTemplate>
+                        <Frame Margin="0,4">
+                            <VerticalStackLayout>
+                                <Label Text="{Binding Description}" />
+                                <Label Text="{Binding Amount, StringFormat='المبلغ: {0:C}'}" />
+                                <Label Text="{Binding CreatedAt, StringFormat='{0:dd/MM/yyyy HH:mm}'}" />
+                            </VerticalStackLayout>
+                        </Frame>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
+
+            <Label Text="آخر عمليات الفليكسي" FontAttributes="Bold" FontSize="20" />
+            <CollectionView ItemsSource="{Binding RecentFlexi}">
+                <CollectionView.ItemTemplate>
+                    <DataTemplate>
+                        <Frame Margin="0,4">
+                            <VerticalStackLayout>
+                                <Label Text="{Binding Notes}" />
+                                <Label Text="{Binding Amount, StringFormat='المبلغ: {0:C}'}" />
+                                <Label Text="{Binding IsPaid, StringFormat='مدفوع: {0}'}" />
+                            </VerticalStackLayout>
+                        </Frame>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
+
+            <Label Text="سجل الجلسات" FontAttributes="Bold" FontSize="20" />
+            <CollectionView ItemsSource="{Binding SessionHistory}">
+                <CollectionView.ItemTemplate>
+                    <DataTemplate>
+                        <Frame Margin="0,4">
+                            <VerticalStackLayout>
+                                <Label Text="{Binding OpenedAt, StringFormat='من {0:dd/MM/yyyy HH:mm}'}" />
+                                <Label Text="{Binding ClosedAt, StringFormat='إلى {0:dd/MM/yyyy HH:mm}'}" />
+                                <Label Text="{Binding NetCashDifference, StringFormat='الفارق: {0:C}'}" />
+                            </VerticalStackLayout>
+                        </Frame>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>

--- a/CashRegisterMaui/Views/UserDashboardPage.xaml.cs
+++ b/CashRegisterMaui/Views/UserDashboardPage.xaml.cs
@@ -1,0 +1,23 @@
+using CashRegisterMaui.Helpers;
+using CashRegisterMaui.ViewModels;
+using Microsoft.Maui.Controls;
+
+namespace CashRegisterMaui.Views;
+
+public partial class UserDashboardPage : ContentPage
+{
+    private readonly UserDashboardViewModel _viewModel;
+
+    public UserDashboardPage()
+    {
+        InitializeComponent();
+        _viewModel = ServiceHelper.GetRequiredService<UserDashboardViewModel>();
+        BindingContext = _viewModel;
+    }
+
+    protected override async void OnAppearing()
+    {
+        base.OnAppearing();
+        await _viewModel.LoadAsync();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
-# CashRegisterApp
+# Cash Register Applications
+
+يحتوي هذا المستودع الآن على إصدارين من التطبيق:
+
+- **CashRegisterApp/**: التطبيق الأصلي المكتوب بـ Python (PyQt + SQLAlchemy).
+- **CashRegisterMaui/**: التطبيق الجديد المبني باستخدام .NET MAUI وEntity Framework Core وMVVM.
+
+## بدء العمل مع مشروع .NET MAUI
+
+1. تثبيت حزم .NET 8 SDK مع دعم MAUI وWorkload الخاصة بالمنصات التي ترغب بالعمل عليها.
+2. من داخل مجلد `CashRegisterMaui` نفّذ أوامر الاستعادة والبناء:
+   ```bash
+   dotnet restore
+   dotnet build
+   ```
+3. لإدارة قاعدة البيانات وتشغيل الهجرات:
+   ```bash
+   dotnet ef migrations add InitialCreate
+   dotnet ef database update
+   ```
+
+### الحسابات المبدئية
+
+- يتم تهيئة مستخدم مدير افتراضي ببيانات الدخول: **admin / admin**.
+
+### البنية
+
+- `Data/`: تعريف `AppDbContext` وتهيئة الكيانات والعلاقات مع دعم الهجرات.
+- `Models/`: الكيانات وقيم الملخص المستخدمة في الواجهات.
+- `Services/`: منطق الأعمال للتوثيق والجلسات والتقارير وإدارة المستخدمين.
+- `ViewModels/`: طبقة MVVM المعتمدة على CommunityToolkit.
+- `Views/`: صفحات XAML مع نماذج أولية لشاشة الدخول ولوحة المستخدم ولوحة المشرف.
+- `Resources/`: الأصول والأنماط المستخدمة في الواجهات.
+
+يمكن تشغيل التطبيق على المنصات المدعومة من MAUI (Android، iOS، MacCatalyst، Windows) بعد إعداد بيئة التطوير المناسبة.


### PR DESCRIPTION
## Summary
- scaffolded a new .NET MAUI solution with EF Core SQLite context, entities, and seed data for an admin account
- implemented services, view models, and XAML views using CommunityToolkit.Mvvm to cover authentication, session handling, reporting, and user management
- added LiveCharts-based admin reporting UI, resource styling, platform bootstrap files, and documentation on building and running migrations

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_b_68d083e71130832eb9d822eba6d7a5d0